### PR TITLE
v0.3.0 Bucket to update parent components

### DIFF
--- a/react/src/App.tsx
+++ b/react/src/App.tsx
@@ -1,10 +1,12 @@
+import { useState } from 'react'
 import { Counter } from './components/Counter'
 import { IndependentCounter } from './components/IndependentCounter'
+import { useUpdate } from './lib'
 import { useMutato } from './lib/useMutato'
 import { store } from './utils/store'
 
 function App() {
-  const mutateStore = useMutato(store)
+  const mutateStore = useMutato('store', store)
 
   const increase = () => {
     // change store with component rerender

--- a/react/src/components/IndependentCounter.tsx
+++ b/react/src/components/IndependentCounter.tsx
@@ -1,13 +1,12 @@
-import { useMutato } from '../lib'
+import { useMutato } from '../lib/useMutato'
 import { store } from '../utils/store'
 
 /*
 It doesn's update upper 
-
 */
 
 const IndependentCounter = () => {
-  const mutate = useMutato(store)
+  const mutate = useMutato('store', store)
 
   const increase = () => mutate(store => store.count += 1)
 

--- a/react/src/lib/types.d.ts
+++ b/react/src/lib/types.d.ts
@@ -1,0 +1,5 @@
+type MutateOperation<T> = (current: T) => void
+
+type Mutato<T> = (mutateOperation: MutateOperation<T>) => void
+
+export type { MutateOperation, Mutato }

--- a/react/src/lib/useLocalMutato.ts
+++ b/react/src/lib/useLocalMutato.ts
@@ -1,0 +1,23 @@
+import { Mutato } from './types'
+import { useUpdate } from './useUpdate'
+
+/*
+
+useLocalMutato:
+  - doesn't rerender parent components
+  - use less memory and faster
+
+*/
+
+const useLocalMutato = <T>(store: T): Mutato<T> => {
+  const forceUpdate = useUpdate()
+
+  const mutate: Mutato<T> = (mutateOperetion) => {
+    mutateOperetion(store)
+    forceUpdate()
+  }
+
+  return mutate
+}
+
+export { useLocalMutato }

--- a/react/src/lib/useMutato.ts
+++ b/react/src/lib/useMutato.ts
@@ -1,6 +1,16 @@
 import { Mutato } from './types'
 import { useUpdate } from './useUpdate'
 
+/*
+
+useMutato:
+  - rerender parent components
+  - can be called from component without passing mutate function as prop
+  - need a bit more memory,
+  because bucket save functions to rerender of highest component
+
+*/
+
 let mutatoBucket = new Map<string, () => void>()
 
 const newUpdate = (key: string) => {

--- a/react/src/lib/useMutato.ts
+++ b/react/src/lib/useMutato.ts
@@ -1,18 +1,23 @@
+import { Mutato } from './types'
 import { useUpdate } from './useUpdate'
 
-type MutateOperation<T> = (current: T) => void
+let mutatoBucket = new Map<string, () => void>()
 
-type Mutato<T> = (mutateOperation: MutateOperation<T>) => void
+const newUpdate = (key: string) => {
+  const update = useUpdate()
+  mutatoBucket.set(key, update)
+  return update
+}
 
-const useMutato = <T>(store: T): Mutato<T> => {
-  const forceUpdate = useUpdate()
+const useMutato = <T>(key: string, store: T): Mutato<T> => {
+  const update = mutatoBucket.get(key) ?? newUpdate(key)
 
-  const mutate: Mutato<T> = (mutateOperetion) => {
+  // return function to mutate state
+  return (mutateOperetion) => {
     mutateOperetion(store)
-    forceUpdate()
+    update()
+    mutatoBucket.delete(key)
   }
-
-  return mutate
 }
 
 export { useMutato }

--- a/react/src/main.tsx
+++ b/react/src/main.tsx
@@ -4,7 +4,7 @@ import App from './App'
 import './global.css'
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+  // <React.StrictMode>
+  <App />
+  // {/* </React.StrictMode> */ }
 )


### PR DESCRIPTION
I made a global bucket to force updates in the highest component where the state is used.
The previous useMutato was renamed to useLocalMutato. It doesn't rerender parent components.